### PR TITLE
Last minute update

### DIFF
--- a/DECORATE.txt
+++ b/DECORATE.txt
@@ -31,6 +31,9 @@
 #include "decorate/Projectiles/FrostMissile_Toby.dec"
 #include "decorate/Projectiles/FlameMissile_Toby.dec"
 #include "decorate/Projectiles/StaffMissile_Toby.dec"
+#include "decorate/Projectiles/HolyMissile_Toby.dec"
+#include "decorate/Projectiles/HolySpirit_Toby.dec"
+#include "decorate/Projectiles/MageStaffFX2_Toby.dec"
 
 //Weapons Directory
 //Fighter

--- a/decorate/Projectiles/HolyMissile_Toby.dec
+++ b/decorate/Projectiles/HolyMissile_Toby.dec
@@ -1,0 +1,7 @@
+//Regardless if this projectile is replaced, for some reason, the +DONTREFLECT flag doesn't work against Heresiarch
+//The spirits will always seek the player once Heresiarch casts his invulnerability spell
+ACTOR HolyMissile_Toby : HolyMissile //replaces HolyMissile
+{
+	+THRUGHOST
+	+DONTREFLECT
+}

--- a/decorate/Projectiles/HolySpirit_Toby.dec
+++ b/decorate/Projectiles/HolySpirit_Toby.dec
@@ -1,0 +1,7 @@
+//Regardless if this projectile is replaced, for some reason, the +DONTREFLECT flag doesn't work against Heresiarch
+//The spirits will always seek the player once Heresiarch casts his invulnerability spell
+ACTOR HolySpirit_Toby : HolySpirit //replaces HolySpirit
+{
+	+THRUGHOST
+	+DONTREFLECT
+}

--- a/decorate/Projectiles/MageStaffFX2_Toby.dec
+++ b/decorate/Projectiles/MageStaffFX2_Toby.dec
@@ -1,0 +1,5 @@
+ACTOR MageStaffFX2_Toby : MageStaffFX2 replaces MageStaffFX2
+{
+	+THRUGHOST
+	+DONTREFLECT
+}


### PR DESCRIPTION
Realized that the projectiles to the Wraithverge and Bloodscourge were not set to be non-reflective. Even though the Bloodscourge projectile works, the same cannot be said for the Wraithverge spirits. No matter what, if you fire the weapon at Heresiarch and he casts his invulnerability spell, those spirits will be coming after you. Not sure how to resolve this but this issue can be resolved in the next major update. I'll probably have to reprogram the projectiles so they cannot be reflected back at the player. I'll have to play around with some ideas.